### PR TITLE
WIP: using `:npm-module` as a poor man's `:modules`

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,5 @@
+const tbd = require('./out/tbd.core')
+const fs = require('fs')
+
+const source = fs.readFileSync(process.argv[process.argv.length - 1]).toString()
+tbd.eval_code(source)

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,26 +1,31 @@
 {:source-paths ["src" "test"]
  :dependencies [[io.nervous/cljs-nodejs-externs "0.2.0"]
+                [reagent "1.1.0"]
                 [borkdude/sci "0.2.6"]]
- :builds {;; :main {:target :node-script
+ :builds {:modules {:target :npm-module
+                    :output-dir "out"
+                    :entries [tbd.core
+                              tbd.reagent]}
+          ;; :main {:target :node-script
           ;;        :main tbd.main/main
           ;;        :output-to "out/dist.js"
           ;;        :exports {}
           ;;        :compiler-options {:infer-externs :auto}}
-          :lib {:target :node-library
-                ;; :main tbd.core/main
-                :output-dir "out"
-                :exports {}
-                :compiler-options {:infer-externs :auto}
-                :js-options {:resolve {"react" {:target :global
-                                                :global "React"}
-                                       "react-dom" {:target :global
-                                                    :global "ReactDOM"}}}
-                :modules
-                {:tbd {:entries [tbd.core]}
-                 :tbd.main {:entries [tbd.main]
-                            :depends-on #{:tbd}}
-                 :tbd.reagent {:entries [tbd.reagent]
-                               :depends-on #{:tbd}}}}
+          ; :lib {:target :node-library
+          ;       ;; :main tbd.core/main
+          ;       :output-dir "out"
+          ;       :exports {}
+          ;       :compiler-options {:infer-externs :auto}
+          ;       :js-options {:resolve {"react" {:target :global
+          ;                                       :global "React"}
+          ;                              "react-dom" {:target :global
+          ;                                           :global "ReactDOM"}}}
+          ;       :modules
+          ;       {:tbd {:entries [tbd.core]}
+          ;        :tbd.main {:entries [tbd.main]
+          ;                   :depends-on #{:tbd}}
+          ;        :tbd.reagent {:entries [tbd.reagent]
+          ;                      :depends-on #{:tbd}}}}
           :test {:target :node-test
                  :output-to "target/test/test.js"
                  :autorun true}}}

--- a/src/tbd/core.cljs
+++ b/src/tbd/core.cljs
@@ -20,8 +20,7 @@
 (def sci-ctx (atom (sci/init {:namespaces {'clojure.core {'prn prn 'println println}}
                               :classes {'js universe :allow :all}})))
 
-(defn ^:export eval-code
-  [code]
+(defn ^:export eval-code [code]
   (let [reader (sci/reader code)]
     (try
       (loop [result nil]

--- a/src/tbd/core.cljs
+++ b/src/tbd/core.cljs
@@ -20,7 +20,8 @@
 (def sci-ctx (atom (sci/init {:namespaces {'clojure.core {'prn prn 'println println}}
                               :classes {'js universe :allow :all}})))
 
-(defn eval! [code]
+(defn ^:export eval-code
+  [code]
   (let [reader (sci/reader code)]
     (try
       (loop [result nil]


### PR DESCRIPTION
The first thing I did was to concentrate both the "core" and "reagent" in a single build-id, so we can interop between then.

Unfortunately, it seems that we lose the ability to generate a `node-script` if we go to this route - that's the "bad part". Other bad part is that `:npm-module` don't work with `shadow-cljs watch`, so we need to `shadow-cljs release modules` before we can use it.

The "good part" is that it works - sorta. I included a simple node-script that loads the `tbd.core` "module", and calls `eval_code` (we can't have the name `eval` because it's reserved by Javascript, and weird things happen if we try to use it). The only thing I'm not really happy is that we don't have only 3 js files: the "main", "tbd.core", and "tbd.reagent" - we have lots of internal ClojureScript and Closure Compiler stuff on the `out` directory :disappointed: 

But, anyway, when we try to eval this code:

```clojure
(require '[reagent.core :as r])
(prn :HELLO :WORLD)
```

It'll fail. But if we add a require:

```clojure
(js/require "./out/tbd.reagent")
(require '[reagent.core :as r])
(prn :HELLO :WORLD)
```

Then it works. We can work up from here, probably :)